### PR TITLE
Update: 반응형 UI 적용 및 CSS 분리

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,3 +9,6 @@
 
 <!-- Minima 테마 기본 CSS  -->
 <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+
+<!-- 반응형 커스텀 CSS -->
+<link rel="stylesheet" href="{{ '/assets/css/responsive.css' | relative_url }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,13 +3,6 @@
 <html lang="ko">
 <head>
   {% include head.html %}
-  <style>
-    .site {
-      max-width: 800px;
-      margin: 0 auto;
-      padding: 20px;
-    }
-  </style>
 </head>
 <body>
   <div class="site">
@@ -17,3 +10,4 @@
   </div>
 </body>
 </html>
+

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -1,0 +1,29 @@
+/* 컨테이너 반응형 설정 */
+.site {
+  width: 90%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+/* 미디어/이미지/표/코드 블록이 넘치지 않도록 */
+.site img,
+.site iframe,
+.site table,
+.site pre {
+  max-width: 100%;
+  height: auto;
+}
+
+/* 코드블록에 가로 스크롤 추가 */
+.site pre {
+  overflow-x: auto;
+}
+
+/* 모바일(≤600px)일 때 패딩 축소 */
+@media (max-width: 600px) {
+  .site {
+    padding: 10px;
+  }
+}


### PR DESCRIPTION
## 변경 사항
- 기존 `_layouts/default.html`에 인라인으로 존재하던 `.site` 스타일을 분리하여 `assets/css/responsive.css`로 이동
- 반응형 대응을 위해 이미지, 테이블, 코드 블럭에 `max-width: 100%` 적용
- 모바일 기기에서는 padding 축소

## 적용 이유
모바일에서 콘텐츠가 잘려 보이는 문제를 해결하고, CSS 구조를 유지보수 가능하도록 개선하기 위함입니다.