### PR TITLE
Fix: 누락된 햄버거 메뉴 CSS 링크 추가

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,3 +13,6 @@
 <!-- 반응형 커스텀 CSS -->
 <link rel="stylesheet" href="{{ '/assets/css/responsive.css' | relative_url }}">
 
+<!-- 햄버거 메뉴 CSS -->
+<link rel="stylesheet" href="{{ '/assets/css/hamburger-menu.css' | relative_url }}">
+


### PR DESCRIPTION
## 🐛 문제

- `hamburger-menu.css` 파일이 head.html에 삽입되지 않아 전체 페이지 레이아웃이 깨지는 현상 발생

## 🔧 해결

- `_includes/head.html`에 해당 CSS 링크를 추가하여 스타일 정상 적용

## ✅ 영향 범위

- 전체 레이아웃 복원
- 햄버거 메뉴와 사이드바가 정상 작동