### PR TITLE
Feat: 블로그 포스트 전용 템플릿(post.html) 생성 및 CSS 분리

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,12 +1,25 @@
 <!-- _includes/head.html -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<title>{{ page.title | escape }}{% if site.title %} | {{ site.title | escape }}{% endif %}</title>
+<title>{% if page.title %}{{ page.title | escape }} | {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+<meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-<!-- 🔮 Favicon 추가 -->
-<link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+<!-- Favicon -->
+<link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
 
 <!-- 햄버거 메뉴 CSS -->
 <link rel="stylesheet" href="{{ '/assets/css/hamburger-menu.css' | relative_url }}">
+
+<!-- Post-specific CSS -->
+{% if page.layout == 'post' %}
+<link rel="stylesheet" href="{{ '/assets/css/post.css' | relative_url }}">
+{% endif %}
+
+<!-- Canonical URL -->
+<link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+
+<!-- RSS Feed -->
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | relative_url }}">
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,66 @@
+---
+layout: default
+---
+
+<article class="post-layout">
+  <div class="post-container">
+    <!-- Post Header -->
+    <header class="post-header">
+      <h1 class="post-title">{{ page.title }}</h1>
+      <div class="post-meta-detail">
+        <time datetime="{{ page.date | date_to_xmlschema }}">
+          {{ page.date | date: "%Y년 %m월 %d일" }}
+        </time>
+        {% if page.categories %}
+          <span class="post-categories">
+            {% for category in page.categories %}
+              <a href="{{ '/categories/' | append: category | downcase | append: '/' | relative_url }}" class="category-link category-{{ category | downcase }}">
+                {{ category }}
+              </a>
+            {% endfor %}
+          </span>
+        {% endif %}
+      </div>
+      {% if page.tags and page.tags.size > 0 %}
+        <div class="post-tags-header">
+          {% for tag in page.tags %}
+            <span class="tag-badge">#{{ tag }}</span>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </header>
+
+    <!-- Post Content -->
+    <div class="post-content">
+      {{ content }}
+    </div>
+
+    <!-- Post Navigation -->
+    <nav class="post-navigation">
+      <div class="nav-links">
+        {% if page.previous %}
+          <div class="nav-previous">
+            <span class="nav-label">이전 글</span>
+            <a href="{{ page.previous.url | relative_url }}" rel="prev">
+              {{ page.previous.title | truncate: 50 }}
+            </a>
+          </div>
+        {% endif %}
+        
+        {% if page.next %}
+          <div class="nav-next">
+            <span class="nav-label">다음 글</span>
+            <a href="{{ page.next.url | relative_url }}" rel="next">
+              {{ page.next.title | truncate: 50 }}
+            </a>
+          </div>
+        {% endif %}
+      </div>
+    </nav>
+
+    <!-- Back to List -->
+    <div class="back-to-list">
+      <a href="{{ '/posts' | relative_url }}" class="btn-secondary">목록으로 돌아가기</a>
+    </div>
+  </div>
+</article>

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -1,0 +1,426 @@
+/* ==========================================================================
+   Post Layout Styles - post.css
+   ========================================================================== */
+
+.post-layout {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.post-container {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  padding: 3rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+/* Post Header */
+.post-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.post-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #333;
+  margin-bottom: 1rem;
+  line-height: 1.3;
+}
+
+.post-meta-detail {
+  font-size: 1rem;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+.post-meta-detail time {
+  margin-right: 1rem;
+}
+
+.post-categories {
+  display: inline-block;
+}
+
+.category-link {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s ease;
+}
+
+.category-link.category-algorithm {
+  background: rgba(255, 107, 53, 0.1);
+  color: #FF6B35;
+}
+
+.category-link.category-ios {
+  background: rgba(247, 147, 30, 0.1);
+  color: #F7931E;
+}
+
+.category-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.post-tags-header {
+  margin-top: 1rem;
+}
+
+.post-tags-header .tag-badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin: 0 0.3rem 0.5rem 0;
+  background: rgba(150, 150, 150, 0.1);
+  color: #8B6B58;
+  border: 1px solid rgba(150, 100, 80, 0.2);
+}
+
+/* Post Content */
+.post-content {
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: #333;
+}
+
+.post-content h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 2.5rem 0 1rem;
+  color: #333;
+}
+
+.post-content h2 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 2rem 0 1rem;
+  color: #333;
+}
+
+.post-content h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 1.75rem 0 0.75rem;
+  color: #333;
+}
+
+.post-content h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.75rem;
+  color: #333;
+}
+
+.post-content p {
+  margin-bottom: 1.25rem;
+}
+
+.post-content ul,
+.post-content ol {
+  margin: 0 0 1.5rem 1.5rem;
+  padding-left: 0.5rem;
+}
+
+.post-content li {
+  margin-bottom: 0.5rem;
+  line-height: 1.7;
+}
+
+.post-content strong {
+  font-weight: 600;
+  color: #222;
+}
+
+.post-content em {
+  font-style: italic;
+}
+
+.post-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  background: rgba(255, 107, 53, 0.05);
+  border-left: 4px solid #FF6B35;
+  font-style: italic;
+  color: #555;
+}
+
+.post-content a {
+  color: #FF6B35;
+  text-decoration: none;
+  font-weight: 500;
+  border-bottom: 1px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.post-content a:hover {
+  border-bottom-color: #FF6B35;
+}
+
+.post-content hr {
+  margin: 2.5rem 0;
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Code Blocks */
+.post-content pre {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 1.5rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.post-content code {
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 0.9em;
+}
+
+/* Inline code */
+.post-content p code,
+.post-content li code {
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: #e91e63;
+  font-size: 0.9em;
+}
+
+/* Code block inside pre should not have background */
+.post-content pre code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+/* Syntax Highlighting Classes */
+.highlight {
+  background: #1e1e1e;
+  border-radius: 8px;
+  margin: 1.5rem 0;
+}
+
+.highlight pre {
+  margin: 0;
+  background: transparent;
+}
+
+/* Language indicator */
+.highlight .language-java::before,
+.highlight .language-python::before,
+.highlight .language-javascript::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.25rem 0.75rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: #999;
+  font-size: 0.8rem;
+  border-bottom-left-radius: 8px;
+  text-transform: uppercase;
+}
+
+/* Syntax colors */
+.highlight .c { color: #6A9955; } /* Comment */
+.highlight .err { color: #f44747; } /* Error */
+.highlight .k { color: #569CD6; } /* Keyword */
+.highlight .l { color: #B5CEA8; } /* Literal */
+.highlight .n { color: #9CDCFE; } /* Name */
+.highlight .o { color: #D4D4D4; } /* Operator */
+.highlight .p { color: #D4D4D4; } /* Punctuation */
+.highlight .cm { color: #6A9955; } /* Comment.Multiline */
+.highlight .cp { color: #569CD6; } /* Comment.Preproc */
+.highlight .c1 { color: #6A9955; } /* Comment.Single */
+.highlight .cs { color: #6A9955; } /* Comment.Special */
+.highlight .gd { color: #f44747; } /* Generic.Deleted */
+.highlight .ge { font-style: italic; } /* Generic.Emph */
+.highlight .gh { color: #9CDCFE; font-weight: bold; } /* Generic.Heading */
+.highlight .gi { color: #B5CEA8; } /* Generic.Inserted */
+.highlight .gp { color: #6A9955; font-weight: bold; } /* Generic.Prompt */
+.highlight .gs { font-weight: bold; } /* Generic.Strong */
+.highlight .gu { color: #9CDCFE; font-weight: bold; } /* Generic.Subheading */
+.highlight .kc { color: #569CD6; } /* Keyword.Constant */
+.highlight .kd { color: #569CD6; } /* Keyword.Declaration */
+.highlight .kn { color: #569CD6; } /* Keyword.Namespace */
+.highlight .kp { color: #569CD6; } /* Keyword.Pseudo */
+.highlight .kr { color: #569CD6; } /* Keyword.Reserved */
+.highlight .kt { color: #4EC9B0; } /* Keyword.Type */
+.highlight .ld { color: #CE9178; } /* Literal.Date */
+.highlight .m { color: #B5CEA8; } /* Literal.Number */
+.highlight .s { color: #CE9178; } /* Literal.String */
+.highlight .na { color: #9CDCFE; } /* Name.Attribute */
+.highlight .nb { color: #9CDCFE; } /* Name.Builtin */
+.highlight .nc { color: #4EC9B0; } /* Name.Class */
+.highlight .no { color: #9CDCFE; } /* Name.Constant */
+.highlight .nd { color: #9CDCFE; } /* Name.Decorator */
+.highlight .ni { color: #9CDCFE; } /* Name.Entity */
+.highlight .ne { color: #4EC9B0; } /* Name.Exception */
+.highlight .nf { color: #DCDCAA; } /* Name.Function */
+.highlight .nl { color: #9CDCFE; } /* Name.Label */
+.highlight .nn { color: #9CDCFE; } /* Name.Namespace */
+.highlight .nt { color: #569CD6; } /* Name.Tag */
+.highlight .nv { color: #9CDCFE; } /* Name.Variable */
+.highlight .ow { color: #D4D4D4; } /* Operator.Word */
+.highlight .w { color: #D4D4D4; } /* Text.Whitespace */
+.highlight .mf { color: #B5CEA8; } /* Literal.Number.Float */
+.highlight .mh { color: #B5CEA8; } /* Literal.Number.Hex */
+.highlight .mi { color: #B5CEA8; } /* Literal.Number.Integer */
+.highlight .mo { color: #B5CEA8; } /* Literal.Number.Oct */
+.highlight .sb { color: #CE9178; } /* Literal.String.Backtick */
+.highlight .sc { color: #CE9178; } /* Literal.String.Char */
+.highlight .sd { color: #CE9178; } /* Literal.String.Doc */
+.highlight .s2 { color: #CE9178; } /* Literal.String.Double */
+.highlight .se { color: #CE9178; } /* Literal.String.Escape */
+.highlight .sh { color: #CE9178; } /* Literal.String.Heredoc */
+.highlight .si { color: #CE9178; } /* Literal.String.Interpol */
+.highlight .sx { color: #CE9178; } /* Literal.String.Other */
+.highlight .sr { color: #D16969; } /* Literal.String.Regex */
+.highlight .s1 { color: #CE9178; } /* Literal.String.Single */
+.highlight .ss { color: #CE9178; } /* Literal.String.Symbol */
+
+/* Images */
+.post-content img {
+  max-width: 100%;
+  height: auto;
+  margin: 1.5rem 0;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+/* Tables */
+.post-content table {
+  width: 100%;
+  margin: 1.5rem 0;
+  border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.post-content th,
+.post-content td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.post-content th {
+  background: rgba(255, 107, 53, 0.1);
+  font-weight: 600;
+  color: #333;
+}
+
+.post-content tr:last-child td {
+  border-bottom: none;
+}
+
+/* Post Navigation */
+.post-navigation {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.nav-links {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.nav-previous,
+.nav-next {
+  flex: 1;
+  min-width: 200px;
+}
+
+.nav-next {
+  text-align: right;
+}
+
+.nav-label {
+  display: block;
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.nav-links a {
+  display: block;
+  color: #333;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover {
+  color: #FF6B35;
+}
+
+/* Back to List */
+.back-to-list {
+  text-align: center;
+  margin-top: 3rem;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .post-layout {
+    padding: 2rem 1rem;
+  }
+  
+  .post-container {
+    padding: 2rem 1.5rem;
+  }
+  
+  .post-title {
+    font-size: 2rem;
+  }
+  
+  .post-content {
+    font-size: 1rem;
+  }
+  
+  .post-content h1 {
+    font-size: 1.75rem;
+  }
+  
+  .post-content h2 {
+    font-size: 1.5rem;
+  }
+  
+  .post-content h3 {
+    font-size: 1.25rem;
+  }
+  
+  .post-content pre {
+    padding: 1rem;
+    font-size: 0.85rem;
+  }
+  
+  .nav-links {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  
+  .nav-next {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## ✨ 블로그 포스트 전용 템플릿 생성 및 구조 정리

### ✅ 주요 변경사항

- `post.html` 생성: 포스트 페이지 전용 레이아웃 템플릿 생성
- `post.css` 생성: 포스트 디자인 전용 스타일 분리
- `_includes/head.html` 수정
  - 중복된 `<meta>`, `<title>`, `<link rel="icon">` 제거
  - `post.html` 에서만 `post.css` 를 로드하도록 조건부 로딩 추가

---

### 💡 작업 의도

- 템플릿 재사용성 및 유지보수 용이성 향상
- head 태그 중복 제거로 코드 가독성 개선
- 특정 레이아웃에서만 필요한 스타일만 로드 → 성능 최적화

---

### 🗂️ 수정 파일

- `_layouts/post.html`
- `/assets/css/post.css`
- `_includes/head.html`

---
